### PR TITLE
bugfix: corrected the reference to params.social .URL parameter in \layouts\contact\list.html

### DIFF
--- a/layouts/contact/list.html
+++ b/layouts/contact/list.html
@@ -30,7 +30,7 @@
       <div class="col-12">
         <ul class="list-inline social-icons text-center">
           {{ range site.Params.social }}
-          <li class="list-inline-item"><a href="{{.link}}"><i class="{{.icon}}"></i></a></li>
+          <li class="list-inline-item"><a href="{{.URL}}"><i class="{{.icon}}"></i></a></li>
           {{ end }}
         </ul>
       </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -265,7 +265,7 @@
         <div class="col-12 text-center">
           <h2 class="section-title">{{site.Data.homepage.blog.title | markdownify }}</h2>
         </div>
-        {{ range first 3 site.RegularPages }}
+        {{ range first 3 (where .Site.RegularPages "Section" "blog")}}
         {{ .Render "post" }}
         {{ end }}
       </div>


### PR DESCRIPTION
bugfix: corrected the reference to config.toml's [params.social] .URL parameter in \layouts\contact\list.html

Prior to this bug-fix, the social icons on the contact page (exampleSite) had broken (blank) HREFs though the same links in index.html were working fine