### PR TITLE
Add Baidu analytics support

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -64,6 +64,8 @@ author = "Johnathan Smith"
 description = "This is meta description"
 # google analytics
 google_analytics_id = "" # Your ID
+# baidu site verification
+baidu_site_verification = "" Your verification code
 # copyright
 copyright = "Copyright &copy; 2021 a Theme by [Gethugothemes](https://gethugothemes.com)"
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -66,6 +66,8 @@ description = "This is meta description"
 google_analytics_id = "" # Your ID
 # baidu site verification
 baidu_site_verification = "" Your verification code
+# baidu analytics
+baidu_analytics_id = "" Your ID
 # copyright
 copyright = "Copyright &copy; 2021 a Theme by [Gethugothemes](https://gethugothemes.com)"
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,6 +8,11 @@
   {{ with site.Params.author }}<meta name="author" content="{{ . }}">{{ end }}
   {{ hugo.Generator }}
 
+  {{ with site.Params.baidu_site_verification }}
+	{{ "<!-- baidu site verification -->" | safeHTML }}
+  <meta name="baidu-site-verification" content="{{ . }}" />
+  {{ end }}
+
   <style>
     :root{
       --primary-color:{{ site.Params.theme_color }};

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -44,4 +44,17 @@
 	</script>
 	{{ end }}
 
+  {{ with site.Params.baidu_analytics_id }}
+	{{ "<!--  Baidu analytics -->" | safeHTML }}
+  <script>
+    var _hmt = _hmt || [];
+    (function() {
+      var hm = document.createElement("script");
+      hm.src = "https://hm.baidu.com/hm.js?{{ . }}";
+      var s = document.getElementsByTagName("script")[0]; 
+      s.parentNode.insertBefore(hm, s);
+    })();
+  </script>
+	{{ end }}
+
 </head>


### PR DESCRIPTION
[https://tongji.baidu.com/ ](https://tongji.baidu.com/)  is a website analysis system similar to Google Analytics.
[https://tongji.baidu.com/ ](https://tongji.baidu.com/)  is a tool that can be used to configure Baidu search engine to include websites.